### PR TITLE
Change 'CMS2' to 'CMS3'

### DIFF
--- a/AutoTuple/submit_crab_jobs.py
+++ b/AutoTuple/submit_crab_jobs.py
@@ -36,7 +36,7 @@ while (lnum <= inFile_size):
   lumi_parts = lumi_line.split()
   numLumiPerJob = lumi_parts[0]
   print numLumiPerJob
-  command = 'python makeCrab3Files.py -CMS2cfg skeleton_cfg.py -d ' + parts[0] + ' -t ' + tag + ' -gtag ' + gtag + ' -isData ' + parts[3] + ' -lumisPerJob ' + numLumiPerJob
+  command = 'python makeCrab3Files.py -CMS3cfg skeleton_cfg.py -d ' + parts[0] + ' -t ' + tag + ' -gtag ' + gtag + ' -isData ' + parts[3] + ' -lumisPerJob ' + numLumiPerJob
   if len(parts) > 4:
     command += ' -sParms ' + parts[4]
   print command

--- a/condorMergingTools/makeCrab3Files.py
+++ b/condorMergingTools/makeCrab3Files.py
@@ -133,9 +133,9 @@ def checkConventions():
 if len(sys.argv) < 9 :
     print 'Usage: makeCrabFiles.py [OPTIONS]'
     print '\nWhere the required options are: '
-    print '\t-CMS2cfg\tname of the skeleton CMS2 config file '
+    print '\t-CMS3cfg\tname of the skeleton CMS3 config file '
     print '\t-d\t\tname of dataset'
-    print '\t-t\t\tCMS2 tag'
+    print '\t-t\t\tCMS3 tag'
     print '\t-gtag\t\tglobal tag'
     print '\nOptional arguments:'
     print '\t-isData\t\tFlag to specify if you are running on data.'
@@ -153,7 +153,7 @@ if len(sys.argv) < 9 :
 
 
 for i in range(0, len(sys.argv)):
-    if sys.argv[i] == '-CMS2cfg':
+    if sys.argv[i] == '-CMS3cfg':
         cmsswSkelFile = sys.argv[i+1]
     if sys.argv[i] == '-d':
         dataSet = sys.argv[i+1]

--- a/condorMergingTools/makeCrabFiles.py
+++ b/condorMergingTools/makeCrabFiles.py
@@ -129,9 +129,9 @@ def checkConventions():
 if len(sys.argv) < 9 :
     print 'Usage: makeCrabFiles.py [OPTIONS]'
     print '\nWhere the required options are: '
-    print '\t-CMS2cfg\tname of the skeleton CMS2 config file '
+    print '\t-CMS3cfg\tname of the skeleton CMS3 config file '
     print '\t-d\t\tname of dataset'
-    print '\t-t\t\tCMS2 tag'
+    print '\t-t\t\tCMS3 tag'
     print '\t-gtag\t\tglobal tag'
     print '\nOptional arguments:'
     print '\t-isData\t\tFlag to specify if you are running on data.'
@@ -149,7 +149,7 @@ if len(sys.argv) < 9 :
 
 
 for i in range(0, len(sys.argv)):
-    if sys.argv[i] == '-CMS2cfg':
+    if sys.argv[i] == '-CMS3cfg':
         cmsswSkelFile = sys.argv[i+1]
     if sys.argv[i] == '-d':
         dataSet = sys.argv[i+1]


### PR DESCRIPTION
I've picked a couple instances where the word 'CMS2' should be changed to 'CMS3'. A few people have gotten confused by this, so I'm attempting to make things more consistent.